### PR TITLE
Better handling if popups are blocked.

### DIFF
--- a/src/Popout.tsx
+++ b/src/Popout.tsx
@@ -186,8 +186,11 @@ export class Popout extends React.Component<PopoutProps, {}> {
             window.open(this.props.url || 'about:blank', name, options)
         );
 
-        if (!this.child && this.props.onBlocked) {
-            this.props.onBlocked();
+        if (!this.child) {
+            if (this.props.onBlocked) {
+                this.props.onBlocked();
+            }
+            this.container = null;
         } else {
             this.id = `__${name}_container__`;
             this.container = this.initializeChildWindow(this.id, this.child!);
@@ -215,7 +218,7 @@ export class Popout extends React.Component<PopoutProps, {}> {
                 this.openChildWindow();
             }
 
-            if (!this.props.url) {
+            if (!this.props.url && this.container) {
                 ReactDOM.render(this.props.children, this.container);
             }
         } else {
@@ -253,7 +256,7 @@ function validateUrl(url: string) {
 }
 
 function validatePopupBlocker(child: Window) {
-    if (!child || child.closed || typeof child.closed == 'undefined') {
+    if (!child || child.closed || typeof child == 'undefined' || typeof child.closed == 'undefined') {
         return null;
     }
 


### PR DESCRIPTION
When popups are blocked, we should do two things:

1) Call the onBlocked prop if it exists
2) Don't try to render anything on that window.

This change should prevent component render errors which, in a React16 world, can cause the entire app to crash unrecoverable.

Resolve #15 