### PR TITLE
Handle Safari 11.1 (and other browsers) when loading URLs

### DIFF
--- a/src/Popout.tsx
+++ b/src/Popout.tsx
@@ -27,8 +27,7 @@ export class Popout extends React.Component<PopoutProps, {}> {
 
         if (child && child.document && child.document.head) {
             const unloadScriptContainer = child.document.createElement('script');
-            unloadScriptContainer.innerHTML = `
-
+            const onBeforeUnloadLogic = `
             window.onbeforeunload = function(e) {
                 var result = window.opener.${
                     globalContext.id
@@ -42,8 +41,20 @@ export class Popout extends React.Component<PopoutProps, {}> {
                 } else {
                     window.opener.${globalContext.id}.onChildClose.call(window.opener, '${id}');
                 }
+            }`;
+            unloadScriptContainer.innerHTML =
+                `
+            window.onload = function(e) {
+                ` +
+                onBeforeUnloadLogic +
+                `
             };
             `;
+
+            // For edge and IE, they don't actually execute the onload logic, so we just want the onBeforeUnload logic.
+            if (isBrowserIEOrEdge()) {
+                unloadScriptContainer.innerHTML = onBeforeUnloadLogic;
+            }
 
             child.document.head.appendChild(unloadScriptContainer);
 
@@ -299,4 +310,10 @@ function forEachStyleElement(
             callback.call(scope, element, i);
         }
     }
+}
+
+function isBrowserIEOrEdge() {
+    const userAgent =
+        typeof navigator != 'undefined' && navigator.userAgent ? navigator.userAgent : '';
+    return /Edge/.test(userAgent) || /Trident/.test(userAgent);
 }

--- a/src/Popout.tsx
+++ b/src/Popout.tsx
@@ -42,6 +42,9 @@ export class Popout extends React.Component<PopoutProps, {}> {
                     window.opener.${globalContext.id}.onChildClose.call(window.opener, '${id}');
                 }
             }`;
+
+            // Use onload for most URL scenarios to allow time for the page to laod first
+            // Safari 11.1 is aggressive, so it will call onbeforeunload prior to the page being created.
             unloadScriptContainer.innerHTML =
                 `
             window.onload = function(e) {

--- a/src/Popout.tsx
+++ b/src/Popout.tsx
@@ -43,14 +43,11 @@ export class Popout extends React.Component<PopoutProps, {}> {
                 }
             }`;
 
-            // Use onload for most URL scenarios to allow time for the page to laod first
+            // Use onload for most URL scenarios to allow time for the page to load first
             // Safari 11.1 is aggressive, so it will call onbeforeunload prior to the page being created.
-            unloadScriptContainer.innerHTML =
-                `
+            unloadScriptContainer.innerHTML = `
             window.onload = function(e) {
-                ` +
-                onBeforeUnloadLogic +
-                `
+                ${onBeforeUnloadLogic}
             };
             `;
 

--- a/src/Popout.tsx
+++ b/src/Popout.tsx
@@ -52,7 +52,8 @@ export class Popout extends React.Component<PopoutProps, {}> {
             `;
 
             // For edge and IE, they don't actually execute the onload logic, so we just want the onBeforeUnload logic.
-            if (isBrowserIEOrEdge()) {
+            // If this isn't a URL scenario, we have to bind onBeforeUnload directly too.
+            if (isBrowserIEOrEdge() || !this.props.url) {
                 unloadScriptContainer.innerHTML = onBeforeUnloadLogic;
             }
 


### PR DESCRIPTION
When loading a URL, Safari 11.1 appears to load the popout first, then load the URL. Unlike other browsers, they appear to call onbeforeunload as they transition from the opened window to the URL. By moving the setting of onbeforeunload post the onload callback, we can ensure this gets set at the proper time for execution.

For IE, Edge, and non URL scenarios, there is never an onload event fired, as we are either directly manipulating the DOM, or IE and Edge are doing their thing. We use the old logic here, and everything works.