### PR TITLE
Added prop for the document.title attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ PopOut Component has the following props:
 ```ts
 export interface PopoutProps {
     hidden?: boolean;
-    name?: string;
+    name?: string;  // refers to the window.name attribute
+    title?: string; // refers to the document.title attribute (use this to give your new window's title bar a proper name!)
     onClose?: () => void;
     onBeforeUnload?: (evt: BeforeUnloadEvent) => string | null | undefined;
     children?: any;

--- a/src/Popout.tsx
+++ b/src/Popout.tsx
@@ -211,6 +211,7 @@ export class Popout extends React.Component<PopoutProps, {}> {
         } else {
             this.id = `__${name}_container__`;
             this.container = this.initializeChildWindow(this.id, this.child!);
+            this.child.document.title = getWindowTitle(this.props.title);
         }
     };
 
@@ -304,6 +305,10 @@ function getWindowName(name: string) {
             .toString(12)
             .slice(2)
     );
+}
+
+function getWindowTitle(title?: string) {
+    return title || '';
 }
 
 function forEachStyleElement(

--- a/src/PopoutProps.ts
+++ b/src/PopoutProps.ts
@@ -3,6 +3,7 @@ import { WindowFeaturesOptions } from './WindowFeaturesOptions';
 export interface PopoutProps {
     hidden?: boolean;
     name?: string;
+    title?: string;
     onClose?: () => void;
     onBeforeUnload?: (evt: BeforeUnloadEvent) => string | null | undefined;
     onBlocked?: () => void;

--- a/test/MyPopout.tsx
+++ b/test/MyPopout.tsx
@@ -19,6 +19,7 @@ export default class MyPopout extends React.Component<MyPopoutProps, any> {
 
         return (
             <Popout
+                title={this.props.title}
                 hidden={this.props.hidden}
                 html={`<!DOCTYPE html><html dir='ltr'><body class='${
                     styles.popout


### PR DESCRIPTION
Issue #32 talks about a window title assignment that's missing from the `<Popout>` component. This causes the popout to generate `"about:blank"` titles, which isn't exactly descriptive.

Are there any tests that I've missed?